### PR TITLE
fixes and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 📝 Apodiktum Modules Changelog:
 
+## 🆕 Version 2.0.22
+### 📃 module updates:
+- admintools | fixed `BlockDoubleLink`
+- admintools | fixed `TypeError: '<' not supported between instances of 'list' and 'float'`
+- msg_merger | `skip_prefix` work in messages with links
+- msg_merger | ignore messages with `prefix`
+
 ## 🆕 Version 2.0.21
 ### 📃 module updates:
 - admintools | added `BlockCustomEmojis`

--- a/admintools.py
+++ b/admintools.py
@@ -258,7 +258,7 @@ class ApodiktumAdminToolsMod(loader.Module):
         )
         self._db_migrator()
         self._pt_task = asyncio.ensure_future(self._global_queue_handler())
-        self._ratelimit_p_count = {"bgs": {}, "bss": {}, "bf": {}}
+        self._ratelimit_p_count = {"bdl": {}, "bf": {}, "bgs": {}, "bss": {}}
         self._ratelimit_notify = {
             "bce": {},
             "bcu": {},
@@ -1861,12 +1861,13 @@ class ApodiktumAdminToolsMod(loader.Module):
             asyncio.ensure_future(
                 self.punish_handler(chat, user, message, module_short, module_sets)
             )
-            if self._ratelimit_p_count[module_short].get(chat.id):
-                for key, value in list(
-                    self._ratelimit_p_count[module_short][chat.id].items()
-                ):
-                    if value < time.time():
-                        self._ratelimit_p_count[module_short][chat.id].pop(key)
+            if (
+                self._ratelimit_p_count[module_short].get(chat.id)
+                and user.id in self._ratelimit_p_count[module_short].get(chat.id)
+                and self._ratelimit_p_count[module_short][chat.id][user.id][0]
+                < time.time()
+            ):
+                self._ratelimit_p_count[module_short][chat.id].pop(user.id)
         else:
             self._ratelimit_p_count[module_short].update(
                 {

--- a/apolib_controller.py
+++ b/apolib_controller.py
@@ -1,4 +1,4 @@
-__version__ = (0, 1, 9)
+__version__ = (0, 1, 12)
 
 
 # ▄▀█ █▄ █ █▀█ █▄ █ █▀█ ▀▀█ █▀█ █ █ █▀
@@ -79,7 +79,7 @@ class ApodiktumLibControllerMod(loader.Module):
             suspend_on_error=True,
         )
         self.apo_lib.apodiktum_module()
-        self._lib_classname = "ApodiktumLib"
+        self._lib_classname = self.apo_lib.__class__.__name__
         self._lib_db = self._db[self._lib_classname]
         self._chats_db = self._lib_db.setdefault("chats", {})
 
@@ -173,3 +173,7 @@ class ApodiktumLibControllerMod(loader.Module):
             message,
             self.apo_lib.utils.get_str("lang_removed", self.all_strings, message),
         )
+
+    @loader.watcher(only_messages=True)
+    async def watcher(self, message: Message):
+        await self.apo_lib.watcher_q.msg_reciever(message)

--- a/msg_merger.py
+++ b/msg_merger.py
@@ -281,14 +281,7 @@ class ApodiktumMsgMergerMod(loader.Module):
         if (
             not self.config["active"]
             or message.via_bot
-            or (
-                message.media
-                and not getattr(message.media, "webpage", False)
-                or (
-                    not self.config["merge_urls"]
-                    and self.apo_lib.utils.get_entityurls(message)
-                )
-            )
+            or message.raw_text.startswith(self.self.get_prefix())
         ):
             return
 
@@ -325,6 +318,13 @@ class ApodiktumMsgMergerMod(loader.Module):
         if (
             self.config["skip_length"]
             and len(utils.remove_html(message.text)) >= self.config["skip_length"]
+        ) or (
+            message.media
+            and not getattr(message.media, "webpage", False)
+            or (
+                not self.config["merge_urls"]
+                and self.apo_lib.utils.get_entityurls(message)
+            )
         ):
             return
         try:


### PR DESCRIPTION
module updates:
- admintools | fixed `BlockDoubleLink`
- admintools | fixed `TypeError: '<' not supported between instances of 'list' and 'float'`
- msg_merger | `skip_prefix` work in messages with links
- msg_merger | ignore messages with `prefix`